### PR TITLE
何週先までの結果を取得するか指定するオプションを追加

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1,14 +1,3 @@
-[root]
-name = "sculd"
-version = "0.1.0"
-dependencies = [
- "chrono 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "getopts 0.2.15 (registry+https://github.com/rust-lang/crates.io-index)",
- "hyper 0.10.12 (registry+https://github.com/rust-lang/crates.io-index)",
- "hyper-rustls 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_json 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
 [[package]]
 name = "base64"
 version = "0.5.2"
@@ -237,6 +226,17 @@ dependencies = [
  "time 0.1.37 (registry+https://github.com/rust-lang/crates.io-index)",
  "untrusted 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "webpki 0.12.1 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "sculd"
+version = "0.1.0"
+dependencies = [
+ "chrono 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "getopts 0.2.15 (registry+https://github.com/rust-lang/crates.io-index)",
+ "hyper 0.10.12 (registry+https://github.com/rust-lang/crates.io-index)",
+ "hyper-rustls 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_json 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]

--- a/src/main.rs
+++ b/src/main.rs
@@ -109,10 +109,13 @@ fn main() {
     }
 
     let weeks = matches.opt_str("w").map(|w| {
-        w.parse::<i64>().unwrap_or_else(|_| panic!("argument to -w must be an integer"))
+        w.parse::<i64>().unwrap_or_else(|_| {
+            die("argument to -w must be an integer".to_string());
+            0xdeadc0de
+        })
     }).map(|w| {
         if w <= 0 {
-            panic!("argument to -w must be an integer greater than 0")
+            die("argument to -w must be an integer greater than 0".to_string())
         }
         w
     });

--- a/src/main.rs
+++ b/src/main.rs
@@ -100,6 +100,7 @@ fn main() {
 
     let mut opts = Options::new();
     opts.optflag("v", "version", "Display version");
+    opts.optopt("w", "weeks", "Get results up till number of weeks (Defaults to 1)", "number", );
 
     let matches = opts.parse(&args[1..]).expect("Failed to parse opts");
     if matches.opt_present("v") {
@@ -107,12 +108,24 @@ fn main() {
         return;
     }
 
+    let weeks = matches.opt_str("w").map(|w| {
+        w.parse::<i64>().unwrap_or_else(|_| panic!("argument to -w must be an integer"))
+    }).map(|w| {
+        if w <= 0 {
+            panic!("argument to -w must be an integer greater than 0")
+        }
+        w
+    });
+
     let url = get_ev("CAMPH_SCHED_URL").expect("Unable to get CAMPH_SCHED_URL");
     let auth = make_auth();
 
     if let Ok(es) = get_sched(url, auth).map_err(die) {
         let today = Local::today();
-        let next = today + chrono::Duration::days(7);
+        let next = match weeks {
+            Some(w) => today + chrono::Duration::days(7 * w),
+            None => today + chrono::Duration::days(7),
+        } ;
 
         let mut res : Vec<&Event> = es.iter()
             .filter(|e| e.start.date() >= today && e.end.date() < next)


### PR DESCRIPTION
## 使用
`-w <weeks>` で何週先までの結果を取得するかを指定．オプションが指定されなかった場合は従来どおり1週間先までの結果を返す．

## 実行例
```
localhost % sculd
2018-06-11 16:30 - 18:00 Open 
2018-06-13 17:30 - 20:00 Open 
2018-06-16 16:00 - 18:00 Open 
localhost % sculd -w 2
2018-06-11 16:30 - 18:00 Open 
2018-06-13 17:30 - 20:00 Open 
2018-06-16 16:00 - 18:00 Open 
2018-06-18 16:30 - 18:00 Open 
2018-06-20 17:30 - 20:00 Open 
2018-06-23 15:30 - 19:00 【LIVESENSE流】Webサービスの開発・運用におけるデー
タエンジニアリング https://camphor.connpass.com/event/87720/
```

## 備考
`panic` で例外の場合に異常終了しているのですが，気持ち悪いのでいい方法をご存知の方はお教えください :bowing_man: 